### PR TITLE
Fix for Order alias ...

### DIFF
--- a/MP-TVSeries/DB Classes/DBEpisode.cs
+++ b/MP-TVSeries/DB Classes/DBEpisode.cs
@@ -1612,7 +1612,8 @@ namespace WindowPlugins.GUITVSeries
                 {
                     ordecolsplit = ordecolsplit.Split(new char[] { '.' })[1];
                 }
-                sqlWhat = sqlWhat.Replace(ordercol, ordercol + " as " + ordercol.Replace(".", "") + " ");
+                // sqlWhat = sqlWhat.Replace(ordercol, ordercol + " as " + ordercol.Replace(".", "") + " ");
+		sqlWhat = Regex.Replace(sqlWhat, ordercol + "\b", ordercol + " as " + ordercol.Replace(".", "")) + " ";
                 orderBy = " order by " + ordercol.Replace(".", "") + (orderBy.Contains(" desc ") ? " desc " : " asc ");
             }
 


### PR DESCRIPTION
Old behavior when order field = online_episodes.Rating :
... online_episodes.Rating, online_episodes.RatingCount .. -> online_episodes.Rating as online_episodesRating , online_episodes.Rating Count ... <- Wrong SQL ...
New behavior:
... online_episodes.Rating, online_episodes.RatingCount .. -> online_episodes.Rating as online_episodesRating , online_episodes.RatingCount ...